### PR TITLE
NEXTEUROPA-12339: Remove uncommon new password request link from authentication scenario

### DIFF
--- a/tests/features/authentication.feature
+++ b/tests/features/authentication.feature
@@ -7,7 +7,6 @@ Scenario: Anonymous user can see the user login page
   Given I am not logged in
   When I visit "user"
   Then I should see the text "ECAS Login"
-  And I should see the text "Request new password"
   And I should see the text "Username"
   And I should see the text "Password"
   But I should not see the text "Log out"


### PR DESCRIPTION
"Request new password" no appear on "/user" page when user registeration is
limited to "administrators only"