### PR TITLE
Update platform version.

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -111,7 +111,7 @@ platform.profile.name = multisite_drupal_standard
 # For most projects you would want to follow 'master' so that you always have
 # the latest version that is deployed on production. Use 'develop' to check if
 # your project is compatible with the upcoming release.
-platform.package.reference = 2.2.152
+platform.package.reference = 2.2.181
 
 # The provider that hosts the platform repository.
 platform.package.provider = git-hub


### PR DESCRIPTION
As the current version of the platform in build.properties.dist is not the one that is on the production, i'm asking to update it to the latest one, still on 2.2 as it's the most used version on production sites.